### PR TITLE
Add forecasting workflow stubs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,11 @@
+1. Analyze existing repository and root AGENTS.md instructions. (done)
+2. Create PLAN.md summarizing tasks.
+3. Add new module `src/workflow.py` with stubs for forecast workflow steps.
+   - Each function will have type hints and Google-style docstrings.
+   - Functions: `clarify_question`, `set_base_rate`, `decompose_problem`, `gather_evidence`, `update_prior`, `produce_forecast`, `sanity_checks`, `cross_validate`, `record_forecast`.
+   - For now, each function raises `NotImplementedError`.
+   - Add dataclasses for `Question`, `BaseRate`, etc. if needed.
+4. Update `src/__init__.py` to export workflow functions.
+5. Create tests in `tests/test_workflow.py` verifying that functions are defined and raise `NotImplementedError` when called.
+6. Run formatting and linting (`ruff format`, `ruff check --fix`), type checking (`mypy .`), and tests (`pytest`).
+7. Commit changes.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,32 @@
 """Public API for the forecasting package."""
 
 from .ollama_utils import execute_tool_calls, generate_search_queries
+from .workflow import (
+    BaseRate,
+    Question,
+    clarify_question,
+    cross_validate,
+    decompose_problem,
+    gather_evidence,
+    produce_forecast,
+    record_forecast,
+    sanity_checks,
+    set_base_rate,
+    update_prior,
+)
 
-__all__ = ["generate_search_queries", "execute_tool_calls"]
+__all__ = [
+    "generate_search_queries",
+    "execute_tool_calls",
+    "Question",
+    "BaseRate",
+    "clarify_question",
+    "set_base_rate",
+    "decompose_problem",
+    "gather_evidence",
+    "update_prior",
+    "produce_forecast",
+    "sanity_checks",
+    "cross_validate",
+    "record_forecast",
+]

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -1,0 +1,75 @@
+"""Stub definitions for the forecasting workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Question:
+    """Forecasting question details."""
+
+    text: str
+    resolution_rule: str | None = None
+    variable_type: str | None = None
+
+
+def clarify_question(question: str) -> Question:
+    """Return a ``Question`` object from raw text.
+
+    Args:
+        question: The question to clarify.
+
+    Returns:
+        A ``Question`` instance.
+    """
+    raise NotImplementedError
+
+
+@dataclass
+class BaseRate:
+    """Base rate prior information."""
+
+    reference_class: str
+    frequency: float
+
+
+def set_base_rate(question: Question) -> BaseRate:
+    """Determine the base rate for a question."""
+    raise NotImplementedError
+
+
+def decompose_problem(question: Question) -> list[Any]:
+    """Break the question into smaller drivers."""
+    raise NotImplementedError
+
+
+def gather_evidence(question: Question) -> list[Any]:
+    """Collect evidence relevant to the question."""
+    raise NotImplementedError
+
+
+def update_prior(base_rate: BaseRate, evidence: list[Any]) -> float:
+    """Update the prior probability based on evidence."""
+    raise NotImplementedError
+
+
+def produce_forecast(probability: float) -> float:
+    """Produce the final forecast probability."""
+    raise NotImplementedError
+
+
+def sanity_checks(probability: float) -> None:
+    """Perform sanity and bias checks on the forecast."""
+    raise NotImplementedError
+
+
+def cross_validate(probability: float) -> None:
+    """Optional cross-validation with external sources."""
+    raise NotImplementedError
+
+
+def record_forecast(question: Question, probability: float) -> None:
+    """Record the forecast and related metadata."""
+    raise NotImplementedError

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from src import (
+    BaseRate,
+    Question,
+    clarify_question,
+    cross_validate,
+    decompose_problem,
+    gather_evidence,
+    produce_forecast,
+    record_forecast,
+    sanity_checks,
+    set_base_rate,
+    update_prior,
+)
+
+
+def test_workflow_stubs() -> None:
+    question_text = "Will AI achieve AGI by 2030?"
+
+    with pytest.raises(NotImplementedError):
+        clarify_question(question_text)
+
+    q = Question(text=question_text)
+
+    with pytest.raises(NotImplementedError):
+        set_base_rate(q)
+
+    with pytest.raises(NotImplementedError):
+        decompose_problem(q)
+
+    with pytest.raises(NotImplementedError):
+        gather_evidence(q)
+
+    base_rate = BaseRate(reference_class="example", frequency=0.1)
+    with pytest.raises(NotImplementedError):
+        update_prior(base_rate, [])
+
+    with pytest.raises(NotImplementedError):
+        produce_forecast(0.5)
+
+    with pytest.raises(NotImplementedError):
+        sanity_checks(0.5)
+
+    with pytest.raises(NotImplementedError):
+        cross_validate(0.5)
+
+    with pytest.raises(NotImplementedError):
+        record_forecast(q, 0.5)


### PR DESCRIPTION
## Summary
- outline steps for implementing a forecasting workflow in `PLAN.md`
- expose new workflow API surface in `src/__init__.py`
- stub out workflow functions in `src/workflow.py`
- add unit tests verifying stub behavior

## Testing
- `ruff format .`
- `ruff check --fix .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846ea4b5dc88323ac8487587a39afb2