### PR TITLE
Implement clarify_question

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ module = [
     "pydantic",
     "pydantic_settings",
     "typer",
+    "typer.testing",
     "playwright.*",
     "brave_search_python_client.*",
     "psutil",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,6 +10,7 @@ from .workflow import (
     gather_evidence,
     produce_forecast,
     record_forecast,
+    run_workflow,
     sanity_checks,
     set_base_rate,
     update_prior,
@@ -29,4 +30,5 @@ __all__ = [
     "sanity_checks",
     "cross_validate",
     "record_forecast",
+    "run_workflow",
 ]

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,8 @@
+from pprint import pprint
+
 import typer  # type: ignore
+
+from src.workflow import run_workflow
 
 app = typer.Typer(help="CLI for forecasting questions")
 
@@ -11,9 +15,9 @@ def forecast(
     """Pose a forecasting question"""
     if verbose:
         typer.echo(f"Forecasting question: {question}")
-    else:
-        typer.echo("Forecasting: " + question)
-    # TODO: integrate forecasting backend
+
+    result = run_workflow(question)
+    pprint(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from pytest_mock import MockerFixture  # type: ignore
+from typer.testing import CliRunner
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.cli import app
+from src.workflow import Question
+
+
+def test_cli_invokes_workflow(mocker: MockerFixture) -> None:
+    q = Question(reasoning="r", text="t")
+    mocker.patch("src.cli.run_workflow", return_value=q)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["Will AI?"])
+    assert result.exit_code == 0
+    assert "reasoning='r'" in result.stdout

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import json
+from typing import Any
+
+import ollama
 import pytest
+from pytest_mock import MockerFixture  # type: ignore
 
 from src import (
     BaseRate,
@@ -11,19 +16,45 @@ from src import (
     gather_evidence,
     produce_forecast,
     record_forecast,
+    run_workflow,
     sanity_checks,
     set_base_rate,
     update_prior,
 )
 
 
-def test_workflow_stubs() -> None:
-    question_text = "Will AI achieve AGI by 2030?"
+def fake_chat_response(data: dict[str, Any]) -> ollama.ChatResponse:
+    return ollama.ChatResponse(message=ollama.Message(role="assistant", content=json.dumps(data)))
 
-    with pytest.raises(NotImplementedError):
-        clarify_question(question_text)
 
-    q = Question(text=question_text)
+def test_clarify_question(mocker: MockerFixture) -> None:
+    data = {
+        "question": "Will AI reach AGI by 2030?",
+        "reasoning": "Analyzing trends",
+        "resolution_rule": "official announcement",
+        "variable_type": "binary",
+    }
+    mocker.patch("src.workflow.ollama.chat", return_value=fake_chat_response(data))
+
+    result = clarify_question("Will AI reach AGI by 2030?")
+    assert isinstance(result, Question)
+    assert result.text == data["question"]
+    assert result.reasoning == data["reasoning"]
+    assert result.resolution_rule == data["resolution_rule"]
+    assert result.variable_type == data["variable_type"]
+
+
+def test_run_workflow_calls_clarify(mocker: MockerFixture) -> None:
+    q = Question(reasoning="r", text="t")
+    clarify_mock = mocker.patch("src.workflow.clarify_question", return_value=q)
+
+    result = run_workflow("q")
+    clarify_mock.assert_called_once_with("q")
+    assert result is q
+
+
+def test_other_stubs() -> None:
+    q = Question(reasoning="", text="Will AI achieve AGI by 2030?")
 
     with pytest.raises(NotImplementedError):
         set_base_rate(q)


### PR DESCRIPTION
## Summary
- extend Question dataclass with `reasoning` field
- implement `clarify_question` using Ollama
- expose `run_workflow` orchestrator
- update CLI to run workflow and pretty-print results
- add tests for workflow and CLI integration
- update mypy config to ignore `typer.testing`

## Testing
- `ruff format .`
- `ruff check --fix .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f55438788323919e9ea571e8b561