### PR TITLE
Implement reference class stage of base rate workflow

### DIFF
--- a/src/workflow.py
+++ b/src/workflow.py
@@ -71,8 +71,48 @@ class BaseRate:
 
 
 def set_base_rate(question: Question) -> BaseRate:
-    """Determine the base rate for a question."""
-    raise NotImplementedError
+    """Determine the base rate for a question.
+
+    Step 1 identifies a suitable reference class for the question using an LLM.
+    Step 2 (measuring the historical frequency) is not yet implemented and the
+    returned ``BaseRate`` therefore uses ``0.0`` as a placeholder for
+    ``frequency``.
+
+    Args:
+        question: The clarified forecasting question.
+
+    Returns:
+        A :class:`BaseRate` with the reference class filled in and ``frequency``
+        set to ``0.0`` until the next step is implemented.
+    """
+
+    system_prompt = (
+        "Suggest an appropriate reference class for the following forecasting "
+        "question. Return JSON with a single field 'reference_class'."
+    )
+
+    response = ollama.chat(
+        model="llama3.3",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": question.text},
+        ],
+        format="json",
+        options={"temperature": 0},
+    )
+
+    content = response.message.content
+    if content is None:
+        raise ValueError("Model returned empty content")
+
+    data = json.loads(content)
+    reference_class = str(data.get("reference_class", ""))
+
+    # TODO: implement measurement of historical frequency based on the chosen
+    # reference class.
+    frequency = 0.0
+
+    return BaseRate(reference_class=reference_class, frequency=frequency)
 
 
 def decompose_problem(question: Question) -> list[Any]:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -53,11 +53,20 @@ def test_run_workflow_calls_clarify(mocker: MockerFixture) -> None:
     assert result is q
 
 
+def test_set_base_rate(mocker: MockerFixture) -> None:
+    q = Question(reasoning="", text="Will AI achieve AGI by 2030?")
+    data = {"reference_class": "past AGI timeline predictions"}
+    chat_mock = mocker.patch("src.workflow.ollama.chat", return_value=fake_chat_response(data))
+
+    result = set_base_rate(q)
+    chat_mock.assert_called_once()
+    assert isinstance(result, BaseRate)
+    assert result.reference_class == data["reference_class"]
+    assert result.frequency == 0.0
+
+
 def test_other_stubs() -> None:
     q = Question(reasoning="", text="Will AI achieve AGI by 2030?")
-
-    with pytest.raises(NotImplementedError):
-        set_base_rate(q)
 
     with pytest.raises(NotImplementedError):
         decompose_problem(q)


### PR DESCRIPTION
## Summary
- implement the `set_base_rate` logic to query an LLM for a reference class
- keep frequency calculation as a TODO and return `0.0`
- add tests for `set_base_rate`

## Testing
- `ruff format .`
- `ruff check --fix .`
- `mypy .`
- `pytest -q`
- `pre-commit run --files src/workflow.py tests/test_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_684726b2fa4c8323919d7649e9d193c3