### PR TITLE
Improve workflow docs and log issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This is a Python project that uses `ruff` for linting and formatting, `mypy` for
 *   **Clarity and Simplicity:** Write code that is easy to read and understand. Add comments for complex logic.
 *   **Naming Conventions:** Use descriptive and meaningful names for variables, functions, and classes. Follow PEP 8 naming conventions (e.g., `snake_case` for functions and variables, `PascalCase` for classes).
 *   **Known Issues:** Review `ISSUES.md` for previously encountered problems and their solutions before starting new work.
+*   **Issue Tracking:** Whenever you encounter a new problem and resolve it, document the details in `ISSUES.md` so future contributors can benefit.
 
 ## 3. Tooling and Commands
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -13,3 +13,17 @@ Solution: added `pytest-cov>=4.1.0` to `pyproject.toml` dependencies.
 Changing `run_workflow` to execute all workflow steps introduced failing tests
 because stubs raise `NotImplementedError`. The tests were updated to mock these
 functions so the workflow can be exercised without executing the stubs.
+
+## LLM Calls in Tests
+
+After implementing the previously stubbed workflow functions, running the tests
+attempted real network calls to the Ollama API. This caused failures when
+Ollama was not available. The solution was to update the unit tests to mock the
+``ollama.chat`` calls and verify the new logic without requiring network
+access.
+
+## Ruff line length errors
+
+When updating docstrings in ``workflow.py`` several lines exceeded the 120
+character limit enforced by Ruff (E501). Formatting failed until the lines were
+wrapped to stay within the limit.


### PR DESCRIPTION
## Summary
- restore enumerated instructions in workflow docstrings
- document ruff line length errors in ISSUES

## Testing
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run mypy .`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68490aa51a5883238f033c891416903f