### PR TITLE
Improve base rate calculation and forecasting workflow

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,16 +4,17 @@ from .ollama_utils import execute_tool_calls, generate_search_queries
 from .workflow import (
     BaseRate,
     Question,
+    apply_evidence,
     clarify_question,
     cross_validate,
     decompose_problem,
     gather_evidence,
     produce_forecast,
+    reconcile_views,
     record_forecast,
     run_workflow,
     sanity_checks,
     set_base_rate,
-    update_prior,
 )
 
 __all__ = [
@@ -25,7 +26,8 @@ __all__ = [
     "set_base_rate",
     "decompose_problem",
     "gather_evidence",
-    "update_prior",
+    "apply_evidence",
+    "reconcile_views",
     "produce_forecast",
     "sanity_checks",
     "cross_validate",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from src.cli import app
 
 
 def test_cli_invokes_workflow(mocker: MockerFixture) -> None:
-    mocker.patch("src.cli.run_workflow", return_value=0.42)
+    mocker.patch("src.cli.run_workflow", return_value={"probability": 0.42, "rationale": "r"})
 
     runner = CliRunner()
     result = runner.invoke(app, ["Will AI?"])

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,6 +10,7 @@ from pytest_mock import MockerFixture  # type: ignore
 from src import (
     BaseRate,
     Question,
+    apply_evidence,
     clarify_question,
     cross_validate,
     decompose_problem,
@@ -19,7 +20,6 @@ from src import (
     run_workflow,
     sanity_checks,
     set_base_rate,
-    update_prior,
 )
 
 
@@ -46,19 +46,20 @@ def test_clarify_question(mocker: MockerFixture) -> None:
 
 def test_run_workflow_sequence(mocker: MockerFixture) -> None:
     q = Question(reasoning="r", text="t")
-    base_rate = BaseRate(reference_class="rc", frequency=0.1)
+    base_rate = BaseRate(reasoning="br", reference_class="rc", frequency=0.1)
     evidence: list[Any] = ["e1"]
-    prior = 0.2
-    probability = 0.3
+    anchor = 0.2
+    probability = {"probability": 0.3, "rationale": "because"}
 
     clarify_mock = mocker.patch("src.workflow.clarify_question", return_value=q)
     base_mock = mocker.patch("src.workflow.set_base_rate", return_value=base_rate)
-    decomp_mock = mocker.patch("src.workflow.decompose_problem")
+    decomp = [{"driver": "combined", "probability": 0.4}]
+    decomp_mock = mocker.patch("src.workflow.decompose_problem", return_value=decomp)
+    reconcile_mock = mocker.patch("src.workflow.reconcile_views", return_value=anchor)
     gather_mock = mocker.patch("src.workflow.gather_evidence", return_value=evidence)
-    update_mock = mocker.patch("src.workflow.update_prior", return_value=prior)
+    apply_mock = mocker.patch("src.workflow.apply_evidence", return_value=0.25)
     produce_mock = mocker.patch("src.workflow.produce_forecast", return_value=probability)
     sanity_mock = mocker.patch("src.workflow.sanity_checks")
-    cross_mock = mocker.patch("src.workflow.cross_validate")
     record_mock = mocker.patch("src.workflow.record_forecast")
 
     result = run_workflow("q")
@@ -66,26 +67,31 @@ def test_run_workflow_sequence(mocker: MockerFixture) -> None:
     clarify_mock.assert_called_once_with("q")
     base_mock.assert_called_once_with(q)
     decomp_mock.assert_called_once_with(q)
+    reconcile_mock.assert_called_once_with(base_rate, decomp)
     gather_mock.assert_called_once_with(q)
-    update_mock.assert_called_once_with(base_rate, evidence)
-    produce_mock.assert_called_once_with(prior)
-    sanity_mock.assert_called_once_with(probability)
-    cross_mock.assert_called_once_with(probability)
-    record_mock.assert_called_once_with(q, probability)
+    apply_mock.assert_called_once_with(anchor, evidence)
+    produce_mock.assert_called_once_with(0.25, q)
+    sanity_mock.assert_called_once()
+    record_mock.assert_called_once_with(q, base_rate, decomp, evidence, probability)
 
     assert result == probability
 
 
 def test_set_base_rate(mocker: MockerFixture) -> None:
     q = Question(reasoning="", text="Will AI achieve AGI by 2030?")
-    data = {"reference_class": "past AGI timeline predictions"}
+    data = {
+        "reference_class": "past AGI timeline predictions",
+        "frequency": 0.3,
+        "reasoning": "analysis",
+    }
     chat_mock = mocker.patch("src.workflow.ollama.chat", return_value=fake_chat_response(data))
 
     result = set_base_rate(q)
     chat_mock.assert_called_once()
     assert isinstance(result, BaseRate)
     assert result.reference_class == data["reference_class"]
-    assert result.frequency == 0.0
+    assert result.frequency == data["frequency"]
+    assert result.reasoning == data["reasoning"]
 
 
 def test_decompose_problem(mocker: MockerFixture) -> None:
@@ -114,29 +120,36 @@ def test_gather_evidence(mocker: MockerFixture) -> None:
     assert result == data
 
 
-def test_update_prior() -> None:
-    base = BaseRate(reference_class="ex", frequency=0.2)
+def test_apply_evidence() -> None:
+    start_prob = 0.2
     evidence = [
         {"likelihood_ratio": 2.0},
         {"likelihood_ratio": 0.5},
     ]
-    result = update_prior(base, evidence)
+    result = apply_evidence(start_prob, evidence)
     assert result == pytest.approx(0.2)
 
 
-def test_produce_forecast() -> None:
-    expected = 0.12
-    assert produce_forecast(0.123) == expected
-    with pytest.raises(ValueError):
-        produce_forecast(1.2)
+def test_produce_forecast(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "src.workflow.ollama.chat",
+        return_value=fake_chat_response("Rationale"),
+    )
+    result = produce_forecast(0.123, Question(reasoning="", text="q"))
+    expected_prob = 0.12
+    assert result["probability"] == expected_prob
 
 
-def test_sanity_and_cross_validate() -> None:
-    sanity_checks(0.5)
+def test_sanity_and_cross_validate(mocker: MockerFixture) -> None:
+    base = BaseRate(reasoning="r", reference_class="rc", frequency=0.5)
+    question = Question(reasoning="r", text="t")
+    decomposition = [
+        {"driver": "combined", "probability": 0.5},
+    ]
+    evidence: list[Any] = []
+    mocker.patch("src.workflow.ollama.chat", return_value=fake_chat_response("critique"))
+    sanity_checks(0.5, base, question, decomposition, evidence)
     cross_validate(0.5)
-
-    with pytest.raises(ValueError):
-        sanity_checks(-0.1)
 
     with pytest.raises(ValueError):
         cross_validate(1.1)
@@ -144,10 +157,14 @@ def test_sanity_and_cross_validate() -> None:
 
 def test_record_forecast(mocker: MockerFixture) -> None:
     q = Question(reasoning="r", text="t")
+    base = BaseRate(reasoning="br", reference_class="rc", frequency=0.1)
+    decomposition: list[Any] = []
+    evidence: list[Any] = []
+    final = {"probability": 0.5, "rationale": "r"}
     m = mocker.mock_open()
     open_mock = mocker.patch("src.workflow.open", m)
-    record_forecast(q, 0.5)
+    record_forecast(q, base, decomposition, evidence, final)
     open_mock.assert_called_once_with("forecasts.jsonl", "a", encoding="utf-8")
     handle = m()
-    expected = json.dumps({"question": q.text, "probability": 0.5}) + "\n"
-    handle.write.assert_called_once_with(expected)
+    written = json.loads(handle.write.call_args.args[0])
+    assert written["final_forecast"] == final


### PR DESCRIPTION
## Summary
- add reasoning field to `BaseRate`
- implement realistic `set_base_rate` with reference class frequency
- add `reconcile_views`, `apply_evidence`, updated `sanity_checks`
- return rationale from `produce_forecast` and record extra details
- overhaul `run_workflow` for superforecasting steps
- update CLI and workflow tests for new behaviour

## Testing
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run mypy .`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491065f61c8323ba93e02dbc05177d